### PR TITLE
Fixing sprites.draw:no Cario context

### DIFF
--- a/sprites.py
+++ b/sprites.py
@@ -330,6 +330,8 @@ class Sprite:
     def draw(self, cr=None):
         ''' Draw the sprite (and label) '''
         if cr is None:
+            cr = self._sprites.cr
+        if cr is None:
             print 'sprite.draw: no Cairo context.'
             return
         for i, surface in enumerate(self.cached_surfaces):


### PR DESCRIPTION
This message was logged again and again.

Fixing it with the help of Fraction bounce version.

Fixes https://github.com/sugarlabs/activity-erikos/issues/8